### PR TITLE
Updated Scintillating Tile GDML files

### DIFF
--- a/barrel_HCAL_gdml/tiles/CTile09_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile09_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="2114.95849609375" y="477.66448974609375" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="2149.891845703125" y="799.2944946289062" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="ChimneyTile09">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="ChimneyTile09"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/CTile09_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile09_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="2149.891845703125" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="2221.36181640625" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="2114.95849609375" y="477.66448974609375" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/CTile10_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile10_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="2537.161865234375" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="2465.69189453125" y="799.2944946289062" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="ChimneyTile10">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="ChimneyTile10"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/CTile10_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile10_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="2414.678466796875" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="2414.678466796875" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="2537.161865234375" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/CTile11_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile11_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="2845.9248046875" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="2774.454833984375" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="2774.454833984375" y="799.2944946289062" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/CTile11_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile11_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="2751.673828125" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="2751.673828125" y="808.344482421875" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="ChimneyTile11">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="ChimneyTile11"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/CTile12_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile12_Reduced.gdml
@@ -23,7 +23,7 @@
   <position name="Mesh2Tess_16" unit="mm" x="3017.741943359375" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_17" unit="mm" x="3039.54248046875" y="808.344482421875" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -64,24 +64,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="ChimneyTile12">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="ChimneyTile12"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/CTile12_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/CTile12_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="3039.54248046875" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="3039.54248046875" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="3116.512451171875" y="519.7784423828125" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile01_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile01_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="0.5" y="0.0" z="3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="238.98008728027344" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="0.5" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile01_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile01_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="0.5" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="67.038330078125" y="799.6744995117188" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured005__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured005__Meshed_">
-        <volumeref ref="LV_Defeatured005__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured005__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile01">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured005__Meshed_" />
-  </setup>
+    <world ref="Tile01"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile02_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile02_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="303.5716247558594" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="303.5716247558594" y="808.344482421875" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile02">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile02"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile02_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile02_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="484.6166687011719" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="167.52841186523438" y="3.469446951953614e-17" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="484.6166687011719" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile03_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile03_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="614.9871826171875" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="727.8602905273438" y="808.344482421875" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile03">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile03"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile03_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile03_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="543.5171508789062" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="339.92645263671875" y="-4.683753385137379e-16" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile04_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile04_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="856.9021606445312" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="856.9021606445312" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="856.9021606445312" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile04_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile04_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="508.9106750488281" y="3.5561831257524545e-15" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="856.9021606445312" y="799.2944946289062" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile04">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile04"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile05_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile05_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="1171.66064453125" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="1100.1905517578125" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="866.001220703125" y="0.0" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile05_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile05_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="1171.66064453125" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="684.9793090820312" y="1.734723475976807e-17" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile05">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile05"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile06_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile06_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="1511.50146484375" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="867.1035766601562" y="4.128641872824801e-15" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="1511.50146484375" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile06_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile06_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="1295.924560546875" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="1367.39453125" y="808.344482421875" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile06">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile06"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile07_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile07_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="1638.95751953125" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="1795.1790771484375" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="1795.1790771484375" y="808.344482421875" z="-3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile07_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile07_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="1252.8128662109375" y="2.048137313163923e-15" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="1567.487548828125" y="799.2944946289062" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile07">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile07"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile08_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile08_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="1852.807861328125" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="1852.807861328125" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="1462.767822265625" y="0.0" z="-3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile08_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile08_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="2094.974853515625" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="1924.27783203125" y="799.2944946289062" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile08">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile08"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile09_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile09_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="-2413.33154296875" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="-1560.988525390625" y="123.9625015258789" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="-2149.891845703125" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile09_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile09_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="-2221.36181640625" y="799.2944946289062" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="-2149.891845703125" y="808.344482421875" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured005__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured005__Meshed_">
-        <volumeref ref="LV_Defeatured005__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured005__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile09">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured005__Meshed_" />
-  </setup>
+    <world ref="Tile09"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile10_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile10_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="-2537.161865234375" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="-2537.161865234375" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="-2414.678466796875" y="808.344482421875" z="3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile10_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile10_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="-2465.69189453125" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="-2465.69189453125" y="808.344482421875" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile10">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile10"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile11_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile11_Reduced.gdml
@@ -21,7 +21,7 @@
   <position name="Mesh2Tess_14" unit="mm" x="-2774.454833984375" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_15" unit="mm" x="-3016.282958984375" y="808.344482421875" z="-3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -58,24 +58,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile11">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile11"/>
+</setup>
 </gdml>

--- a/barrel_HCAL_gdml/tiles/Tile11_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile11_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="-3016.282958984375" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="-2774.454833984375" y="799.2944946289062" z="-3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="-2845.9248046875" y="808.344482421875" z="-3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile12_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile12_Reduced.gdml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='us-ascii'?>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
   <define>
-    <constant name="HALFPI" value="pi/2." />
-  <constant name="PI" value="1.*pi" />
-  <constant name="TWOPI" value="2.*pi" />
   <position name="Mesh2Tess_0" unit="mm" x="-3116.512451171875" y="808.344482421875" z="-3.5" />
   <position name="Mesh2Tess_1" unit="mm" x="-3116.512451171875" y="808.344482421875" z="3.5" />
   <position name="Mesh2Tess_2" unit="mm" x="-3039.54248046875" y="808.344482421875" z="-3.5" />

--- a/barrel_HCAL_gdml/tiles/Tile12_Reduced.gdml
+++ b/barrel_HCAL_gdml/tiles/Tile12_Reduced.gdml
@@ -23,7 +23,7 @@
   <position name="Mesh2Tess_16" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="-3.5" />
   <position name="Mesh2Tess_17" unit="mm" x="-2600.395263671875" y="123.9625015258789" z="3.5" />
   <position name="center" x="0" y="0" z="0" unit="mm" />
-  <rotation name="identity" x="0" y="0" z="0" />
+  <rotation name="identity" x="0" y="0" z="0" unit="deg" />
   </define>
 <materials />
 <solids>
@@ -64,24 +64,11 @@
     </tessellated>
   </solids>
 <structure>
-    <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_AIR" />
-    <solidref ref="WorldBox" />
-    <physvol name="PV-dummy">
-        <volumeref ref="dummy" />
-      </physvol>
-    <physvol name="PV-LV_Defeatured001__Meshed_">
-        <volumeref ref="LV_Defeatured001__Meshed_" />
-      <positionref ref="center" />
-      <rotationref ref="identity" />
-      </physvol>
-    </volume>
-  <volume name="LV_Defeatured001__Meshed_">
-      <materialref ref="G4_A-150_TISSUE" />
-    <solidref ref="Mesh2Tess" />
-    </volume>
-  </structure>
+  <volume name="Tile12">
+    <solidref ref="Mesh2Tess"/>
+  </volume>
+</structure>
 <setup name="Default" version="1.0">
-    <world ref="LV_Defeatured001__Meshed_" />
-  </setup>
+    <world ref="Tile12"/>
+</setup>
 </gdml>


### PR DESCRIPTION
### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
None

### Does this PR change default behavior?
Not by itself.  The scintillating tile GDML files have been updated so they could be properly used directly instead of having the solid information stored in the barrel HCAL GDML file. This will be incorporated into a separate request to the epic library
